### PR TITLE
Use python 3.8 for doc builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,13 +5,13 @@ on:
 name: Tests
 jobs:
   doc_tests:
-    name: Doc Tests / Python 3.6
+    name: Doc Tests / Python 3.8
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Python 3.6
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.8
       - name: Checkout repository
         uses: actions/checkout@v2
         with:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,7 +17,7 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.6
+  version: 3.8
   install:
     - method: pip
       path: .


### PR DESCRIPTION
Updates python version to 3.8 for doc builds on RTD. Branch protection rules will be updated to also require doc builds to pass on RTD.