### PR TITLE
Add parameter for maximum data

### DIFF
--- a/composeml/data_slice/extension.py
+++ b/composeml/data_slice/extension.py
@@ -94,10 +94,11 @@ class DataSliceExtension:
     def _apply(self, size, start, stop, step, drop_empty=True):
         """Generates data slices based on the data frame."""
         df = self._apply_start(self._df, start, step)
-        if df.empty: return df
+        if df.empty and drop_empty: return df
 
         df, slice_number = DataSliceFrame(df), 1
-        while not df.empty and start.value <= stop.value:
+        while start.value and start.value <= stop.value:
+            if df.empty and drop_empty: break
             ds = self._apply_size(df, start, size)
             df = self._apply_step(df, start, step)
             if ds.empty and drop_empty: continue
@@ -153,8 +154,7 @@ class DataSliceExtension:
             start.value = first_index
         else:
             start.value += step.value
-            if start.value <= self._last_index:
-                df = df[start.value:]
+            df = df[start.value:]
 
         return df
 

--- a/composeml/data_slice/generator.py
+++ b/composeml/data_slice/generator.py
@@ -4,10 +4,11 @@ from composeml.data_slice.extension import DataSliceContext, DataSliceFrame
 class DataSliceGenerator:
     """Generates data slices for the lable maker."""
 
-    def __init__(self, window_size, gap=None, min_data=None, drop_empty=True):
+    def __init__(self, window_size, gap=None, min_data=None, max_data=None, drop_empty=True):
         self.window_size = window_size
         self.gap = gap
         self.min_data = min_data
+        self.max_data = max_data
         self.drop_empty = drop_empty
 
     def __call__(self, df):
@@ -39,6 +40,7 @@ class DataSliceGenerator:
         data_slices = df.slice(
             size=self.window_size,
             start=self.min_data,
+            stop=self.max_data,
             step=self.gap,
             drop_empty=self.drop_empty,
         )

--- a/composeml/label_maker.py
+++ b/composeml/label_maker.py
@@ -62,13 +62,14 @@ class LabelMaker:
         assert isinstance(value, dict), 'value type for labeling function not supported'
         self._labeling_function = value
 
-    def slice(self, df, num_examples_per_instance, minimum_data=None, gap=None, drop_empty=True):
+    def slice(self, df, num_examples_per_instance, minimum_data=None, maximum_data=None, gap=None, drop_empty=True):
         """Generates data slices of target entity.
 
         Args:
             df (DataFrame): Data frame to create slices on.
             num_examples_per_instance (int): Number of examples per unique instance of target entity.
-            minimum_data (str): Minimum data before starting search. Default value is first time of index.
+            minimum_data (str): Minimum data before starting the search. Default value is first time of index.
+            maximum_data (str): Maximum data before stopping the search. Default value is last time of index.
             gap (str or int): Time between examples. Default value is window size.
                 If an integer, search will start on the first event after the minimum data.
             drop_empty (bool): Whether to drop empty slices. Default value is True.
@@ -84,6 +85,7 @@ class LabelMaker:
         generator = DataSliceGenerator(
             window_size=self.window_size,
             min_data=minimum_data,
+            max_data=maximum_data,
             drop_empty=drop_empty,
             gap=gap,
         )
@@ -181,6 +183,7 @@ class LabelMaker:
                df,
                num_examples_per_instance,
                minimum_data=None,
+               maximum_data=None,
                gap=None,
                drop_empty=True,
                verbose=True,
@@ -192,7 +195,8 @@ class LabelMaker:
             df (DataFrame): Data frame to search and extract labels.
             num_examples_per_instance (int or dict): The expected number of examples to return from each entity group.
                 A dictionary can be used to further specify the expected number of examples to return from each label.
-            minimum_data (str): Minimum data before starting search. Default value is first time of index.
+            minimum_data (str): Minimum data before starting the search. Default value is first time of index.
+            maximum_data (str): Maximum data before stopping the search. Default value is last time of index.
             gap (str or int): Time between examples. Default value is window size.
                 If an integer, search will start on the first event after the minimum data.
             drop_empty (bool): Whether to drop empty slices. Default value is True.
@@ -211,6 +215,7 @@ class LabelMaker:
         generator = DataSliceGenerator(
             window_size=self.window_size,
             min_data=minimum_data,
+            max_data=maximum_data,
             drop_empty=drop_empty,
             gap=gap,
         )
@@ -231,6 +236,7 @@ class LabelMaker:
             search_settings={
                 'num_examples_per_instance': num_examples_per_instance,
                 'minimum_data': str(minimum_data),
+                'maximum_data': str(maximum_data),
                 'window_size': str(self.window_size),
                 'gap': str(gap),
             },

--- a/composeml/tests/test_label_maker.py
+++ b/composeml/tests/test_label_maker.py
@@ -523,3 +523,26 @@ def test_search_with_maximum_data(transactions):
 
     actual = lt.pipe(to_csv, index=False)
     assert actual == expected
+
+    lt = lm.search(
+        df=transactions.sort_values('time'),
+        num_examples_per_instance=-1,
+        maximum_data='30min',
+        drop_empty=False,
+        gap='30min',
+    )
+
+    expected = [
+        'customer_id,time,len',
+        '0,2019-01-01 08:00:00,2',
+        '0,2019-01-01 08:30:00,1',
+        '1,2019-01-01 09:00:00,2',
+        '1,2019-01-01 09:30:00,2',
+        '2,2019-01-01 10:30:00,2',
+        '2,2019-01-01 11:00:00,2',
+        '3,2019-01-01 12:30:00,1',
+        '3,2019-01-01 13:00:00,0',
+    ]
+
+    actual = lt.pipe(to_csv, index=False)
+    assert actual == expected

--- a/composeml/tests/test_label_maker.py
+++ b/composeml/tests/test_label_maker.py
@@ -491,3 +491,35 @@ def test_label_type(transactions, total_spent_fn):
     lt = lm.search(transactions, num_examples_per_instance=1)
     assert lt.target_types['total_spent'] == 'continuous'
     assert lt.bin(2).target_types['total_spent'] == 'discrete'
+
+
+def test_search_with_maximum_data(transactions):
+    lm = LabelMaker(
+        target_entity='customer_id',
+        time_index='time',
+        labeling_function=len,
+        window_size='1h',
+    )
+
+    lt = lm.search(
+        df=transactions.sort_values('time'),
+        num_examples_per_instance=-1,
+        minimum_data='2019-01-01 08:00:00',
+        maximum_data='2019-01-01 09:00:00',
+        drop_empty=False,
+    )
+
+    expected = [
+        'customer_id,time,len',
+        '0,2019-01-01 08:00:00,2',
+        '0,2019-01-01 09:00:00,0',
+        '1,2019-01-01 08:00:00,0',
+        '1,2019-01-01 09:00:00,2',
+        '2,2019-01-01 08:00:00,0',
+        '2,2019-01-01 09:00:00,0',
+        '3,2019-01-01 08:00:00,0',
+        '3,2019-01-01 09:00:00,0',
+    ]
+
+    actual = lt.pipe(to_csv, index=False)
+    assert actual == expected

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,6 +4,18 @@ Release Notes
 
 |
 
+**Future Release**
+    * Enhancements
+      * Add ``maximum_data`` parameter to control when a search should stop (:pr:`216`)
+    * Fixes
+    * Documentation Changes
+    * Testing Changes
+
+    | Thanks to the following people for contributing to this release:
+    | :user:`jeff-hernandez`
+
+|
+
 **v0.6.0** February 11, 2021
     * Enhancements
         * Added description for continuous target distributions (:pr:`187`)


### PR DESCRIPTION
Closes #213 by adding a `maximum_data` parameter to control when the label search should stop. You can use this parameter to generate year-to-date labels.

```python
lt = lm.search(
  ...
  minimum_data='2021-01-01',
  maximum_data='2021-05-03',
  drop_empty=False,
)
```