### PR TITLE
Automated Minimum Dependency Updates

### DIFF
--- a/.github/workflows/minimum_dependency_checker.yml
+++ b/.github/workflows/minimum_dependency_checker.yml
@@ -1,7 +1,5 @@
 name: Minimum Dependency Checker
 on:
-  pull_request:
-    types: [opened, synchronize]
   push:
     branches:
       - main

--- a/.github/workflows/minimum_dependency_checker.yml
+++ b/.github/workflows/minimum_dependency_checker.yml
@@ -59,4 +59,4 @@ jobs:
           branch: min-dep-update
           branch-suffix: short-commit-hash
           base: main
-          reviewers: thehomebrewnerd, tamargrey, jeff-hernandez
+          reviewers: rwedge, jeff-hernandez

--- a/compose/tests/requirement_files/minimum_core_requirements.txt
+++ b/compose/tests/requirement_files/minimum_core_requirements.txt
@@ -1,0 +1,5 @@
+pandas==0.23.0
+numpy==1.13.3
+tqdm==4.19.2
+matplotlib==3.0.2
+seaborn==0.11.0

--- a/compose/tests/requirement_files/minimum_test_requirements.txt
+++ b/compose/tests/requirement_files/minimum_test_requirements.txt
@@ -1,0 +1,9 @@
+pytest==4.4.1
+pytest-cov==2.6.1
+fastparquet==0.1.6
+codecov==2.1.0
+flake8==3.7.8
+autopep8==1.4.4
+isort==4.3.21
+packaging==20.4
+featuretools==0.9.0


### PR DESCRIPTION
This is an auto-generated PR with **minimum** dependency updates. Please do not delete the `min-dep-update` branch because it's needed by the auto-dependency bot.