### PR TITLE
Add token for code coverage report

### DIFF
--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -42,3 +42,4 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,6 +14,7 @@ Release Notes
         * Add minimum dependency checker to generate minimum requirement files (:pr:`218`)
         * Add CI workflow for unit tests with minimum dependencies (:pr:`220`)
         * Create separate worksflows for each CI job (:pr:`220`)
+        * Pass token to authorize uploading of codecov reports (:pr:`224`)
 
     | Thanks to the following people for contributing to this release:
     | :user:`gsheni`, :user:`jeff-hernandez`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,7 +14,7 @@ Release Notes
         * Add minimum dependency checker to generate minimum requirement files (:pr:`218`)
         * Add CI workflow for unit tests with minimum dependencies (:pr:`220`)
         * Create separate worksflows for each CI job (:pr:`220`)
-        * Pass token to authorize uploading of codecov reports (:pr:`224`)
+        * Pass token to authorize uploading of codecov reports (:pr:`226`)
 
     | Thanks to the following people for contributing to this release:
     | :user:`gsheni`, :user:`jeff-hernandez`


### PR DESCRIPTION
Closes #225 by adding Codecov token to upload code coverage reports.