### PR TITLE
Automated Latest Dependency Updates

### DIFF
--- a/.github/workflows/latest_dependency_checker.yml
+++ b/.github/workflows/latest_dependency_checker.yml
@@ -40,4 +40,4 @@ jobs:
         branch: latest-dep-update
         branch-suffix: short-commit-hash
         base: main
-        reviewers: gsheni, jeff-hernandez
+        reviewers: thehomebrewnerd, tamargrey, jeff-hernandez, tuethan1999, davesque, simha104 

--- a/.github/workflows/minimum_dependency_checker.yml
+++ b/.github/workflows/minimum_dependency_checker.yml
@@ -59,4 +59,4 @@ jobs:
           branch: min-dep-update
           branch-suffix: short-commit-hash
           base: main
-          reviewers: rwedge, jeff-hernandez
+          reviewers: thehomebrewnerd, tamargrey, jeff-hernandez, tuethan1999, davesque, simha104 

--- a/composeml/tests/requirement_files/latest_core_dependencies.txt
+++ b/composeml/tests/requirement_files/latest_core_dependencies.txt
@@ -3,6 +3,6 @@ featuretools==0.26.1
 matplotlib==3.4.3
 matplotlib-inline==0.1.2
 pandas==1.2.4
-seaborn==0.11.1
-tqdm==4.62.0
+seaborn==0.11.2
+tqdm==4.62.1
 woodwork==0.4.2


### PR DESCRIPTION
This is an auto-generated PR with **latest** dependency updates. Please do not delete the `latest-dep-update` branch because it's needed by the auto-dependency bot.