### PR TITLE
Varying first cutoff time for each target group

### DIFF
--- a/composeml/label_maker.py
+++ b/composeml/label_maker.py
@@ -78,7 +78,7 @@ class LabelMaker:
             minimum_data (int or str or Series): The amount of data needed before starting the search. Defaults to the first value in the time index.            
                 The value can be a datetime string to directly set the first cutoff time or a timedelta string to denote the amount of data needed before
                 the first cutoff time. The value can also be an integer to denote the number of rows needed before the first cutoff time.
-                If a Series, minimum_data should be datetime string or integer values with a unique set of target groups as the corresponding index.
+                If a Series, minimum_data should be datetime string, timedelta string, or integer values with a unique set of target groups as the corresponding index.
             maximum_data (str): Maximum data before stopping the search. Default value is last time of index.
             gap (str or int): Time between examples. Default value is window size.
                 If an integer, search will start on the first event after the minimum data.
@@ -150,7 +150,7 @@ class LabelMaker:
             minimum_data (int or str or Series): The amount of data needed before starting the search. Defaults to the first value in the time index.            
                 The value can be a datetime string to directly set the first cutoff time or a timedelta string to denote the amount of data needed before
                 the first cutoff time. The value can also be an integer to denote the number of rows needed before the first cutoff time.
-                If a Series, minimum_data should be datetime string or integer values with a unique set of target groups as the corresponding index.
+                If a Series, minimum_data should be datetime string, timedelta string, or integer values with a unique set of target groups as the corresponding index.
             maximum_data (str): Maximum data before stopping the search. Defaults to the last value in the time index.
             gap (str or int): Time between examples. Default value is window size.
                 If an integer, search will start on the first event after the minimum data.

--- a/composeml/label_maker.py
+++ b/composeml/label_maker.py
@@ -75,7 +75,7 @@ class LabelMaker:
         Args:
             df (DataFrame): Data frame to create slices on.
             num_examples_per_instance (int): Number of examples per unique instance of target entity.
-            minimum_data (int or str or Series): The amount of data needed before starting the search. Defaults to the first value in the time index.            
+            minimum_data (int or str or Series): The amount of data needed before starting the search. Defaults to the first value in the time index.
                 The value can be a datetime string to directly set the first cutoff time or a timedelta string to denote the amount of data needed before
                 the first cutoff time. The value can also be an integer to denote the number of rows needed before the first cutoff time.
                 If a Series, minimum_data should be datetime string, timedelta string, or integer values with a unique set of target groups as the corresponding index.
@@ -147,7 +147,7 @@ class LabelMaker:
             df (DataFrame): Data frame to search and extract labels.
             num_examples_per_instance (int or dict): The expected number of examples to return from each entity group.
                 A dictionary can be used to further specify the expected number of examples to return from each label.
-            minimum_data (int or str or Series): The amount of data needed before starting the search. Defaults to the first value in the time index.            
+            minimum_data (int or str or Series): The amount of data needed before starting the search. Defaults to the first value in the time index.
                 The value can be a datetime string to directly set the first cutoff time or a timedelta string to denote the amount of data needed before
                 the first cutoff time. The value can also be an integer to denote the number of rows needed before the first cutoff time.
                 If a Series, minimum_data should be datetime string, timedelta string, or integer values with a unique set of target groups as the corresponding index.

--- a/composeml/label_maker.py
+++ b/composeml/label_maker.py
@@ -75,7 +75,10 @@ class LabelMaker:
         Args:
             df (DataFrame): Data frame to create slices on.
             num_examples_per_instance (int): Number of examples per unique instance of target entity.
-            minimum_data (str): Minimum data before starting the search. Default value is first time of index.
+            minimum_data (int or str or Series): The amount of data needed before starting the search. Defaults to the first value in the time index.            
+                The value can be a datetime string to directly set the first cutoff time or a timedelta string to denote the amount of data needed before
+                the first cutoff time. The value can also be an integer to denote the number of rows needed before the first cutoff time.
+                If a Series, minimum_data should be datetime string or integer values with a unique set of target groups as the corresponding index.
             maximum_data (str): Maximum data before stopping the search. Default value is last time of index.
             gap (str or int): Time between examples. Default value is window size.
                 If an integer, search will start on the first event after the minimum data.
@@ -144,9 +147,11 @@ class LabelMaker:
             df (DataFrame): Data frame to search and extract labels.
             num_examples_per_instance (int or dict): The expected number of examples to return from each entity group.
                 A dictionary can be used to further specify the expected number of examples to return from each label.
-            minimum_data (str or Series): Minimum data before starting the search. Defaults to the first value in the time index.
-                If a Series, minimum_data should be values and unique target groups should be the corresponding index.
-            maximum_data (str): Maximum data before stopping the search. Defaults to the laste value in the time index.
+            minimum_data (int or str or Series): The amount of data needed before starting the search. Defaults to the first value in the time index.            
+                The value can be a datetime string to directly set the first cutoff time or a timedelta string to denote the amount of data needed before
+                the first cutoff time. The value can also be an integer to denote the number of rows needed before the first cutoff time.
+                If a Series, minimum_data should be datetime string or integer values with a unique set of target groups as the corresponding index.
+            maximum_data (str): Maximum data before stopping the search. Defaults to the last value in the time index.
             gap (str or int): Time between examples. Default value is window size.
                 If an integer, search will start on the first event after the minimum data.
             drop_empty (bool): Whether to drop empty slices. Default value is True.

--- a/composeml/label_maker.py
+++ b/composeml/label_maker.py
@@ -144,8 +144,9 @@ class LabelMaker:
             df (DataFrame): Data frame to search and extract labels.
             num_examples_per_instance (int or dict): The expected number of examples to return from each entity group.
                 A dictionary can be used to further specify the expected number of examples to return from each label.
-            minimum_data (str): Minimum data before starting the search. Default value is first time of index.
-            maximum_data (str): Maximum data before stopping the search. Default value is last time of index.
+            minimum_data (str or Series): Minimum data before starting the search. Defaults to the first value in the time index.
+                If a Series, minimum_data should be values and unique target groups should be the corresponding index.
+            maximum_data (str): Maximum data before stopping the search. Defaults to the laste value in the time index.
             gap (str or int): Time between examples. Default value is window size.
                 If an integer, search will start on the first event after the minimum data.
             drop_empty (bool): Whether to drop empty slices. Default value is True.

--- a/composeml/tests/test_data_slice/test_extension.py
+++ b/composeml/tests/test_data_slice/test_extension.py
@@ -64,3 +64,10 @@ def test_time_index_error(transactions):
     match = 'offset by frequency requires a time index'
     with raises(AssertionError, match=match):
         transactions.slice[::'1h']
+
+
+def test_minimum_data_per_group(transactions):
+    lm = LabelMaker('customer_id', labeling_function=len, time_index='time', window_size='1h')
+    minimum_data = {1: '2019-01-01 09:00:00', 3: '2019-01-01 12:00:00'}
+    lengths = [len(ds) for ds in lm.slice(transactions, 1, minimum_data=minimum_data)]
+    assert lengths == [2, 1]

--- a/composeml/tests/test_featuretools.py
+++ b/composeml/tests/test_featuretools.py
@@ -38,7 +38,7 @@ def labels():
 def test_dfs(labels):
     target_column = labels.target_columns[0]
     es = ft.demo.load_mock_customer(return_entityset=True, random_seed=0)
-    feature_matrix, _ = ft.dfs(entityset=es, target_dataframe_name='customers', cutoff_time=labels, cutoff_time_in_index=True)
+    feature_matrix, _ = ft.dfs(entityset=es, target_entity='customers', cutoff_time=labels, cutoff_time_in_index=True)
     assert target_column in feature_matrix
 
     columns = ['customer_id', 'time', target_column]

--- a/composeml/tests/test_featuretools.py
+++ b/composeml/tests/test_featuretools.py
@@ -38,7 +38,7 @@ def labels():
 def test_dfs(labels):
     target_column = labels.target_columns[0]
     es = ft.demo.load_mock_customer(return_entityset=True, random_seed=0)
-    feature_matrix, _ = ft.dfs(entityset=es, target_entity='customers', cutoff_time=labels, cutoff_time_in_index=True)
+    feature_matrix, _ = ft.dfs(entityset=es, target_dataframe_name='customers', cutoff_time=labels, cutoff_time_in_index=True)
     assert target_column in feature_matrix
 
     columns = ['customer_id', 'time', target_column]

--- a/composeml/tests/test_label_maker.py
+++ b/composeml/tests/test_label_maker.py
@@ -550,20 +550,18 @@ def test_search_with_maximum_data(transactions):
 
 def test_minimum_data_per_group(transactions):
     lm = LabelMaker('customer_id', labeling_function=len, time_index='time', window_size='1h')
-    minimum_data_dict = {1: '2019-01-01 09:00:00', 3: '2019-01-01 12:00:00'}
-    supported_types = minimum_data_dict, pd.Series(minimum_data_dict)
+    for minimum_data in [{1: '2019-01-01 09:30:00', 2: '2019-01-01 11:30:00'}, {1: '30min', 2: '1h'}, {1: 1, 2: 2}]:
+        for supported_type in [minimum_data, pd.Series(minimum_data)]:
+            lt = lm.search(transactions, 1, minimum_data=supported_type)
+            actual = to_csv(lt, index=False)
 
-    for minimum_data in supported_types:
-        lt = lm.search(transactions, 1, minimum_data=minimum_data)
-        actual = to_csv(lt, index=False)
+            expected = [
+                'customer_id,time,len',
+                '1,2019-01-01 09:30:00,2',
+                '2,2019-01-01 11:30:00,2'
+            ]
 
-        expected = [
-            'customer_id,time,len',
-            '1,2019-01-01 09:00:00,2',
-            '3,2019-01-01 12:00:00,1',
-        ]
-
-        assert actual == expected
+            assert actual == expected
 
 
 def test_minimum_data_per_group_error(transactions):

--- a/composeml/tests/test_label_maker.py
+++ b/composeml/tests/test_label_maker.py
@@ -547,6 +547,7 @@ def test_search_with_maximum_data(transactions):
     actual = lt.pipe(to_csv, index=False)
     assert actual == expected
 
+
 @pytest.mark.parametrize("minimum_data", [{1: '2019-01-01 09:30:00', 2: '2019-01-01 11:30:00'}, {1: '30min', 2: '1h'}, {1: 1, 2: 2}])
 def test_minimum_data_per_group(transactions, minimum_data):
     lm = LabelMaker('customer_id', labeling_function=len, time_index='time', window_size='1h')

--- a/composeml/tests/test_label_maker.py
+++ b/composeml/tests/test_label_maker.py
@@ -547,21 +547,20 @@ def test_search_with_maximum_data(transactions):
     actual = lt.pipe(to_csv, index=False)
     assert actual == expected
 
-
-def test_minimum_data_per_group(transactions):
+@pytest.mark.parametrize("minimum_data", [{1: '2019-01-01 09:30:00', 2: '2019-01-01 11:30:00'}, {1: '30min', 2: '1h'}, {1: 1, 2: 2}])
+def test_minimum_data_per_group(transactions, minimum_data):
     lm = LabelMaker('customer_id', labeling_function=len, time_index='time', window_size='1h')
-    for minimum_data in [{1: '2019-01-01 09:30:00', 2: '2019-01-01 11:30:00'}, {1: '30min', 2: '1h'}, {1: 1, 2: 2}]:
-        for supported_type in [minimum_data, pd.Series(minimum_data)]:
-            lt = lm.search(transactions, 1, minimum_data=supported_type)
-            actual = to_csv(lt, index=False)
+    for supported_type in [minimum_data, pd.Series(minimum_data)]:
+        lt = lm.search(transactions, 1, minimum_data=supported_type)
+        actual = to_csv(lt, index=False)
 
-            expected = [
-                'customer_id,time,len',
-                '1,2019-01-01 09:30:00,2',
-                '2,2019-01-01 11:30:00,2'
-            ]
+        expected = [
+            'customer_id,time,len',
+            '1,2019-01-01 09:30:00,2',
+            '2,2019-01-01 11:30:00,2'
+        ]
 
-            assert actual == expected
+        assert actual == expected
 
 
 def test_minimum_data_per_group_error(transactions):

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,4 @@ jupyter==1.0.0
 nbsphinx==0.8.6
 pydata-sphinx-theme==0.6.3
 evalml==0.28.0
+scikit-learn>=0.24.0,<1.0

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Release Notes
     * Enhancements
         * Add ``maximum_data`` parameter to control when a search should stop (:pr:`216`)
         * Add optional automatic update checker (:pr:`223`, :pr:`229`, :pr:`232`)
+        * Varying first cutoff time for each target group (:pr:`258`)
     * Fixes
     * Documentation Changes
         * Update doc tutorials to the latest API changes (:pr:`227`)

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -8,6 +8,7 @@ Use these guides to learn how to use label transformations and generate better t
     :glob:
     :maxdepth: 1
 
+    user_guide/controlling_cutoff_times
     user_guide/using_label_transforms
     user_guide/data_slice_generator
 

--- a/docs/source/user_guide/controlling_cutoff_times.ipynb
+++ b/docs/source/user_guide/controlling_cutoff_times.ipynb
@@ -1,0 +1,227 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fcfef470",
+   "metadata": {},
+   "source": [
+    "# Controlling cutoff times in a label search\n",
+    "\n",
+    "The start time of the labeling process is known as the first cutoff time. You need data that exists before the first cutoff time to build features. You can use `minimum_data` in a label search to directly define the first cutoff time or the amount of data needed before the first cutoff time. Similarly, you can use `maximum_data` to directly define the last cutoff time. These parameters let you control when the labeling process starts and finishes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3cc3d374",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "from io import StringIO\n",
+    "from pandas import read_csv\n",
+    "\n",
+    "transaction_data = \"\"\"\n",
+    "customer_id,transaction_time,amount\n",
+    "3,2021-03-31 18:51:27,52.29\n",
+    "5,2021-03-22 06:56:05,33.81\n",
+    "5,2021-03-20 23:45:21,76.3\n",
+    "2,2021-03-30 10:06:59,32.72\n",
+    "1,2021-02-17 11:01:22,59.16\n",
+    "2,2021-01-16 10:59:44,56.33\n",
+    "3,2021-01-12 07:53:00,61.84\n",
+    "4,2021-03-15 21:00:25,34.91\n",
+    "2,2021-01-26 10:01:37,69.88\n",
+    "2,2021-02-07 05:42:14,49.7\n",
+    "2,2021-03-15 16:35:16,41.08\n",
+    "4,2021-02-06 13:17:19,32.34\n",
+    "2,2021-02-21 09:42:48,86.15\n",
+    "4,2021-03-24 00:40:24,97.08\n",
+    "4,2021-03-23 04:27:47,58.81\n",
+    "4,2021-02-23 13:32:22,59.67\n",
+    "4,2021-02-10 03:46:16,96.36\n",
+    "3,2021-03-13 09:24:54,25.4\n",
+    "1,2021-01-27 13:58:38,26.15\n",
+    "3,2021-02-23 03:26:58,28.96\n",
+    "1,2021-01-05 09:55:18,24.6\n",
+    "1,2021-03-09 07:14:27,49.64\n",
+    "1,2021-02-10 23:27:37,31.29\n",
+    "2,2021-01-23 18:19:05,42.88\n",
+    "1,2021-01-05 22:50:52,58.58\n",
+    "\"\"\"\n",
+    "\n",
+    "created_account_data = \"\"\"\n",
+    "customer_id,created_account\n",
+    "1,2021-01-10\n",
+    "2,2021-02-12\n",
+    "3,2021-01-23\n",
+    "4,2021-02-13\n",
+    "5,2021-01-24\n",
+    "\"\"\"\n",
+    "\n",
+    "with StringIO(transaction_data) as data:\n",
+    "    transactions = read_csv(data, parse_dates=['transaction_time'])\n",
+    "    \n",
+    "with StringIO(created_account_data) as data:\n",
+    "    created_account = read_csv(data, parse_dates=['created_account'], index_col='customer_id')['created_account']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a49db5e1",
+   "metadata": {},
+   "source": [
+    "## Labeling customer transactions\n",
+    "\n",
+    "For example, suppose you have customer transactions from the first quarter of 2021."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf63bed2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import composeml as cp\n",
+    "\n",
+    "transactions.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6d19fff",
+   "metadata": {},
+   "source": [
+    "You want to calculate the total amount that customers spent over two weeks *only for February*. Start by defining a labeling function that sums up the transaction amount. Then, create a label maker that will label data over two weeks using the transaction time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6cb2d34a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def total_amount(ds):\n",
+    "    return ds.amount.sum()\n",
+    "\n",
+    "\n",
+    "lm = cp.LabelMaker(\n",
+    "    labeling_function=total_amount,\n",
+    "    time_index='transaction_time',\n",
+    "    target_entity='customer_id',\n",
+    "    window_size='14d',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dee27ce4",
+   "metadata": {},
+   "source": [
+    "### Defining the first and last cutoff time\n",
+    "\n",
+    "Now, you can use `minimum_data` in the label search to directly set the 1st of February as the first cutoff time. Since you are labeling data over two weeks, you can define the last cutoff time as the 15th."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "953ee7c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lt = lm.search(\n",
+    "    df=transactions.sort_values('transaction_time'),\n",
+    "    num_examples_per_instance=-1,\n",
+    "    minimum_data='2021-02-01',\n",
+    "    maximum_data='2021-02-15',\n",
+    "    drop_empty=False,\n",
+    "    verbose=False,\n",
+    ")\n",
+    "\n",
+    "lt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c23c02ae",
+   "metadata": {},
+   "source": [
+    "### Changing the first cutoff time for each customer\n",
+    "\n",
+    "Suppose you have a lookup table that contains the dates when customers signed up and created their accounts. Now, you are interested in calculating the total amount that customers spent over two weeks *only after creating an account*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5fb84606",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "created_account"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4edf1235",
+   "metadata": {},
+   "source": [
+    "You can use the column of sign up dates directly as the first cutoff times in the labeling process. Each customer should only have one cutoff time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8463785d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lt = lm.search(\n",
+    "    df=transactions.sort_values('transaction_time'),\n",
+    "    num_examples_per_instance=-1,\n",
+    "    minimum_data=created_account,\n",
+    "    drop_empty=False,\n",
+    "    verbose=False,\n",
+    ")\n",
+    "\n",
+    "lt.head(10)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "cc91d60c",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "For more details on labeling data over specific periods, you can look at the guide on :doc:`generating data slices </user_guide/data_slice_generator>`."
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Edit Metadata",
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,4 +9,4 @@ codecov==2.1.8
 flake8==3.7.8
 autopep8==1.4.4
 isort==4.3.21
-featuretools>=0.18.0
+featuretools>=0.18.0,<1.0


### PR DESCRIPTION
Closes #215 by supporting columns as values for `minimum_data` in a label search.  This functionality allows users to vary the first cutoff time for each target group. For example, with a table of customers, you can start the labeling process at the varying times that the accounts were created.