### PR TITLE
Add woodwork to test requirements

### DIFF
--- a/.github/workflows/lint_check.yml
+++ b/.github/workflows/lint_check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.9"]
     steps:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/composeml/tests/requirement_files/minimum_test_requirements.txt
+++ b/composeml/tests/requirement_files/minimum_test_requirements.txt
@@ -4,5 +4,5 @@ pytest-cov==2.10.1
 wheel==0.33.1
 fastparquet==0.5.0
 featuretools==1.4.0
-evalml==0.41.0
-woodwork==0.14.0
+evalml==0.45.0
+woodwork==0.8.1

--- a/composeml/tests/requirement_files/minimum_test_requirements.txt
+++ b/composeml/tests/requirement_files/minimum_test_requirements.txt
@@ -5,3 +5,4 @@ wheel==0.33.1
 fastparquet==0.5.0
 featuretools==1.4.0
 evalml==0.41.0
+woodwork==0.14.0

--- a/composeml/tests/requirement_files/minimum_test_requirements.txt
+++ b/composeml/tests/requirement_files/minimum_test_requirements.txt
@@ -4,5 +4,5 @@ pytest-cov==2.10.1
 wheel==0.33.1
 fastparquet==0.5.0
 featuretools==1.4.0
-evalml==0.45.0
+evalml==0.41.0
 woodwork==0.8.1

--- a/composeml/tests/requirement_files/minimum_test_requirements.txt
+++ b/composeml/tests/requirement_files/minimum_test_requirements.txt
@@ -5,4 +5,4 @@ wheel==0.33.1
 fastparquet==0.5.0
 featuretools==1.4.0
 evalml==0.41.0
-woodwork==0.8.1
+woodwork==0.11.0

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -12,9 +12,10 @@ Future Release
         * Update README.md with Alteryx link (:pr:`289`, :pr:`290`)
         * Add in-line tabs and copy-paste functionality to docs (:pr:`293`)
     * Testing Changes
+        * Add woodwork to ``test-requirements.txt`` (:pr:`296`)
 
     | Thanks to the following people for contributing to this release:
-    | :user:`gsheni`, :user:`mingdavidqi`
+    | :user:`gsheni`, :user:`mingdavidqi`, :user:`thehomebrewnerd`
 
 **v0.8.0** January 20, 2022
     * Enhancements

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,5 +5,5 @@ wheel>=0.33.1
 fastparquet==0.5.0
 featuretools>=1.4.0
 woodwork>=0.8.1
-evalml==0.41.0; python_version == '3.7' 
+evalml==0.41.0; python_version == '3.7'
 evalml>=0.45.0; python_version >= '3.8'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,5 +5,5 @@ wheel>=0.33.1
 fastparquet==0.5.0
 featuretools>=1.4.0
 woodwork>=0.8.1
-evalml==0.41.0; python_version == '3.7'
+evalml==0.41.0; python_version == '3.7' 
 evalml>=0.45.0; python_version >= '3.8'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,4 +5,5 @@ wheel>=0.33.1
 fastparquet==0.5.0
 featuretools>=1.4.0
 woodwork>=0.8.1
-evalml>=0.45.0
+evalml==0.41.0; python_version == '3.7'
+evalml>=0.45.0; python_version >= '3.8'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,5 +4,5 @@ pytest-cov==2.10.1
 wheel>=0.33.1
 fastparquet==0.5.0
 featuretools>=1.4.0
-woodwork>=0.14.0
+woodwork>=0.8.1
 evalml==0.41.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,4 +6,4 @@ fastparquet==0.5.0
 featuretools>=1.4.0
 woodwork>=0.8.1
 evalml==0.41.0; python_version == '3.7'
-evalml>=0.45.0; python_version >= '3.8' 
+evalml>=0.45.0; python_version >= '3.8'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,4 +6,4 @@ fastparquet==0.5.0
 featuretools>=1.4.0
 woodwork>=0.8.1
 evalml==0.41.0; python_version == '3.7'
-evalml>=0.45.0; python_version >= '3.8'
+evalml>=0.45.0; python_version >= '3.8' 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,6 +4,6 @@ pytest-cov==2.10.1
 wheel>=0.33.1
 fastparquet==0.5.0
 featuretools>=1.4.0
-woodwork>=0.8.1
+woodwork>=0.11.0
 evalml==0.41.0; python_version == '3.7'
 evalml>=0.45.0; python_version >= '3.8'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,4 +5,4 @@ wheel>=0.33.1
 fastparquet==0.5.0
 featuretools>=1.4.0
 woodwork>=0.8.1
-evalml==0.41.0
+evalml>=0.45.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,4 +4,5 @@ pytest-cov==2.10.1
 wheel>=0.33.1
 fastparquet==0.5.0
 featuretools>=1.4.0
+woodwork>=0.14.0
 evalml==0.41.0


### PR DESCRIPTION
These updates force test with Featuretools `1.4.0` to run with Woodwork `0.11.0`, but the tests with Featuretools `1.7.0` will run with the latest Woodwork release of `0.14.0`.