### PR TITLE
Handle categorical target with unused categories

### DIFF
--- a/composeml/label_maker.py
+++ b/composeml/label_maker.py
@@ -1,6 +1,7 @@
 from sys import stdout
 
 from pandas import Series
+from pandas.api.types import is_categorical_dtype
 from tqdm import tqdm
 
 from composeml.data_slice import DataSliceGenerator
@@ -205,6 +206,11 @@ class LabelMaker:
 
         df = self.set_index(df)
         total = search.expected_count if search.is_finite else 1
+        # If the target is categorical, make sure there are no unused categories
+        if is_categorical_dtype(df[self.target_dataframe_name]):
+            df[self.target_dataframe_name] = df[
+                self.target_dataframe_name
+            ].cat.remove_unused_categories()
         target_groups = df.groupby(self.target_dataframe_name)
         total *= target_groups.ngroups
 

--- a/composeml/tests/test_label_maker.py
+++ b/composeml/tests/test_label_maker.py
@@ -599,3 +599,16 @@ def test_minimum_data_per_group_error(transactions):
 
     with pytest.raises(ValueError, match=match):
         lm.search(transactions, 1, minimum_data=minimum_data)
+
+
+def test_label_maker_categorical_target_with_missing_data(transactions, total_spent_fn):
+    transactions = transactions.copy()
+    transactions["customer_id"] = transactions["customer_id"].astype("category")
+    lm = LabelMaker(
+        target_dataframe_name="customer_id",
+        time_index="time",
+        window_size=3,
+        labeling_function=total_spent_fn,
+    )
+    # use on only the first 8 rows so the df will not contain data for customer 3
+    lm.search(transactions.head(8), -1)

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,13 +5,14 @@ Future Release
 ==============
     * Enhancements
     * Fixes
+        * Update to avoid error with a categorical target with unused categories (:pr:`349`)
     * Changes
     * Documentation Changes
     * Testing Changes
         * Add create feedstock PR workflow (:pr:`346`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`
+    :user:`gsheni`, :user:`thehomebrewnerd`
     
 v0.9.1 Nov 2, 2022
 ==================


### PR DESCRIPTION
Closes #274 

Removes any unused categories in a categorical target during `lm.search` to avoid identifying target groups that contain no data.