### PR TITLE
Restrict scikit-learn

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,9 +8,9 @@ Future Release
         * Update to avoid error with a categorical target with unused categories (:pr:`349`)
     * Changes
         * Transition to pure pyproject.toml for project metadata (:pr:`351`)
-        * Change `target_dataframe_name` parameter name to `target_dataframe_index` (:pr:`353`)
-        * Temporarily restrict scikit-learn version to ``<1.2.0`` (:pr:`361`)
+        * Change ``target_dataframe_name`` parameter name to ``target_dataframe_index`` (:pr:`353`)
     * Documentation Changes
+        * Temporarily restrict scikit-learn version to ``<1.2.0`` in dev requirements to allow docs to build (:pr:`361`)
     * Testing Changes
         * Add create feedstock PR workflow (:pr:`346`)
 
@@ -19,7 +19,7 @@ Future Release
 
 Breaking Changes
 ++++++++++++++++
-* The parameter `target_dataframe_name` has been changed to `target_dataframe_index` in ``LabelMaker``.
+* The parameter ``target_dataframe_name`` has been changed to ``target_dataframe_index`` in ``LabelMaker``.
 
 v0.9.1 Nov 2, 2022
 ==================

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Future Release
     * Changes
         * Transition to pure pyproject.toml for project metadata (:pr:`351`)
         * Change `target_dataframe_name` parameter name to `target_dataframe_index` (:pr:`353`)
+        * Temporarily restrict scikit-learn version to ``<1.2.0`` (:pr:`361`)
     * Documentation Changes
     * Testing Changes
         * Add create feedstock PR workflow (:pr:`346`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dev = [
     "jupyter == 1.0.0",
     "pandoc == 1.1.0",
     "ipykernel == 6.4.2",
-    "scikit-learn >= 0.20.0, !=0.22",
+    "scikit-learn >= 0.20.0, !=0.22, <1.2.0",
 ]
 complete = [
     "composeml[updater]",


### PR DESCRIPTION
The latest version of sklearn causes errors with EvalML. Until the next release of EvalML is out that restricts sklearn, we need to restrict scklearn here to allow the docs to build properly.